### PR TITLE
[XTI-329] Connector health monitoring

### DIFF
--- a/external-import/ibm-xti/src/external_import_connector/connector.py
+++ b/external-import/ibm-xti/src/external_import_connector/connector.py
@@ -6,6 +6,8 @@ from typing import NotRequired, Optional, TypedDict, cast
 from pycti import OpenCTIConnectorHelper
 from stix2 import TAXIICollectionSource
 
+from external_import_connector.health import HealthCheck
+
 from .client_api import ConnectorClient
 from .config_variables import ConfigConnector
 
@@ -259,6 +261,9 @@ class ConnectorIBMXTI:
         Example: `CONNECTOR_DURATION_PERIOD=PT5M` => Will run the process every 5 minutes
         :return: None
         """
+        health_check = HealthCheck(self.__helper)
+        health_check.register_thread()
+
         self.__helper.schedule_iso(
             message_callback=self.process_message,
             duration_period=self.__config.duration_period,  # type: ignore

--- a/external-import/ibm-xti/src/external_import_connector/health.py
+++ b/external-import/ibm-xti/src/external_import_connector/health.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta, timezone
+from threading import Thread
+from fastapi import FastAPI
+from pycti import OpenCTIConnectorHelper
+import uvicorn
+
+
+class HealthCheck:
+    __helper: OpenCTIConnectorHelper
+    __app: FastAPI
+
+    def __init__(self, helper):
+        self.__helper = helper
+        self.__app = FastAPI()
+
+    def __ping(self):
+        if not self.__helper.api.health_check():
+            raise ConnectionError("OpenCTI API health check failed")
+
+        current_state = self.__helper.get_state()
+        if current_state and (last_run := current_state["last_run"]):
+            last_run_dt = datetime.strptime(last_run, "%Y-%m-%d %H:%M:%S")
+            if last_run_dt < datetime.now() - timedelta(minutes=10):
+                raise TimeoutError("Connector has not run in the last 2 intervals")
+
+        return {'success': True}
+
+    def __listen(self):
+        self.__app.get("/health")(self.__ping)
+
+        self.__helper.connector_logger.info("Health check listening on port 8080")
+        uvicorn.run(self.__app, host="0.0.0.0", port=8080)
+
+    def register_thread(self):
+        t = Thread(target=self.__listen, daemon=True)
+        t.start()

--- a/external-import/ibm-xti/src/requirements.txt
+++ b/external-import/ibm-xti/src/requirements.txt
@@ -4,3 +4,4 @@ stix2
 taxii2-client
 markdown-it-py
 cvss
+fastapi[standard]


### PR DESCRIPTION
**Testing:**

1. Run the connector with `python src/main.py` from the `external-import/ibm-xti` directory
2. Test the health check with `curl http://localhost:8080/health`. You should get a success message
3. Force an error on the health check. For example, change [this line](https://github.com/ibm-xti/opencti-connector-ibm-xti/pull/18/files#diff-a8f9ed43cc79b5ddfe7cf0657f9ed7d9a4625f03bcdd6dcf8e6df6c37c51bb40R17) to remove the `not`
4. Test the health check and verify that you receive a 500 error